### PR TITLE
Use MultiPV:2 instead of evaluating all legal moves

### DIFF
--- a/modules/investigate/investigate.py
+++ b/modules/investigate/investigate.py
@@ -12,7 +12,7 @@ def material_value(board):
     return sum(v * (len(board.pieces(pt, True)) + len(board.pieces(pt, False))) for v, pt in zip([0,3,3,5.5,9], chess.PIECE_TYPES))
 
 def material_count(board):
-    return chess.pop_count(board.occupied)
+    return chess.popcount(board.occupied)
 
 def investigate(a, b, board):
     # determine if the difference between position A and B 

--- a/modules/puzzle/position_list.py
+++ b/modules/puzzle/position_list.py
@@ -131,17 +131,17 @@ class position_list:
         if len(self.analysed_legals) > 1:
             if (self.analysed_legals[0].evaluation.cp is not None
                 and self.analysed_legals[1].evaluation.cp is not None):
-                if (self.analysed_legals[0].evaluation.cp > -210
-                    or self.analysed_legals[1].evaluation.cp < -90):
+                if (self.analysed_legals[0].evaluation.cp < 210
+                    or self.analysed_legals[1].evaluation.cp > 90):
                     return True
             if (self.analysed_legals[0].evaluation.mate is not None
                 and self.analysed_legals[1].evaluation.mate is not None):
-                if (self.analysed_legals[0].evaluation.mate < 1
-                    and self.analysed_legals[1].evaluation.mate < 1):
+                if (self.analysed_legals[0].evaluation.mate > -1
+                    and self.analysed_legals[1].evaluation.mate > -1):
                     return True
             if (self.analysed_legals[0].evaluation.mate is not None
                 and self.analysed_legals[1].evaluation.cp is not None):
-                if (self.analysed_legals[1].evaluation.cp < -200):
+                if (self.analysed_legals[1].evaluation.cp > 200):
                     return True
         return False
 

--- a/modules/puzzle/position_list.py
+++ b/modules/puzzle/position_list.py
@@ -72,20 +72,23 @@ class position_list:
             logging.debug(bcolors.FAIL + "No best move!" + bcolors.ENDC)
             return False
 
-    def evaluate_legals(self, nodes=6000000):
-        logging.debug(bcolors.OKGREEN + "Evaluating Legal Moves..." + bcolors.ENDC)
-        for i in self.position.legal_moves:
-            position_copy = self.position.copy()
-            position_copy.push(i)
-            self.engine.position(position_copy)
-            self.engine.go(nodes=nodes)
-            self.analysed_legals.append(analysed(i, self.info_handler.info["score"][1]))
-        self.analysed_legals = sorted(self.analysed_legals, key=methodcaller('sort_val'))
-        for i in self.analysed_legals[:3]:
+    def evaluate_legals(self, nodes=12000000):
+        logging.debug(bcolors.OKGREEN + "Evaluating Best Two Legal Moves..." + bcolors.ENDC)
+        self.engine.setoption({"MultiPV": 2})
+        self.engine.position(self.position)
+        self.engine.go(nodes=nodes)
+        move1 = self.engine.info_handlers[0].info["pv"].get(1)[0]
+        score1 = self.engine.info_handlers[0].info["score"].get(1)
+        self.analysed_legals.append(analysed(move1, score1))
+        move2 = self.engine.info_handlers[0].info["pv"].get(2)[0]
+        score2 = self.engine.info_handlers[0].info["score"].get(2)
+        self.analysed_legals.append(analysed(move2, score2))
+
+        for i in self.analysed_legals:
             logging.debug(bcolors.OKGREEN + "Move: " + str(i.move.uci()) + bcolors.ENDC)
             logging.debug(bcolors.OKBLUE + "   CP: " + str(i.evaluation.cp))
             logging.debug("   Mate: " + str(i.evaluation.mate))
-        logging.debug("... and " + str(max(0, len(self.analysed_legals) - 3)) + " more moves" + bcolors.ENDC)
+        self.engine.setoption({"MultiPV": 1})
 
     def material_difference(self):
         return sum(v * (len(self.position.pieces(pt, True)) - len(self.position.pieces(pt, False))) for v, pt in zip([0,3,3,5.5,9], chess.PIECE_TYPES))

--- a/modules/puzzle/position_list.py
+++ b/modules/puzzle/position_list.py
@@ -94,7 +94,7 @@ class position_list:
         return sum(v * (len(self.position.pieces(pt, True)) - len(self.position.pieces(pt, False))) for v, pt in zip([0,3,3,5.5,9], chess.PIECE_TYPES))
 
     def material_count(self):
-        return chess.pop_count(self.position.occupied)
+        return chess.popcount(self.position.occupied)
 
     def is_complete(self, category, color, first_node, first_val):
         if self.next_position is not None:


### PR DESCRIPTION
While adapting this project to work locally, I came across a solution to speed up the process all together.

When investigating a puzzle position, `evaluate_legals()` made a list of all legal moves, played them on the board, and got the engine analysis of that position.  It then sorted all the analyzed positions by evaluation, and checked for ambiguity within moves (only one good move should be in a puzzle).  However, only the first two moves in the sorted `analysed_legals` were used to check ambiguity in the puzzle.  Meaning many more moves were evaluated at 6 million nodes, at each step during the puzzle investigation.  Furthermore, those moves were played onto the board for the engine to evaluate, taking up more computation time and space. 

Using a MultiPV value of 2, Stockfish is able to provide us with it's top two picks for moves using only one go command.  Since this evaluation is of the current position before the move, as opposed to the move being made and the position after being evaluated, all of the inequality signs had to be flipped, and numbers negated in `ambiguous()`.  With some testing I found out simply multiple the nodes in `evaluate_legals()` by 2 was enough to make sure both PVs were analyzed by stockfish with the same depth as individually.  (On higher MultiPVs the nodes are split amongst the PVs, so without increasing nodes the analysis would be less accurate)

I've tested these changes on my locally adapted version (found on the master branch of https://github.com/forhavu/Python-Puzzle-Creator/) and found around a 400% speed increase on my machine, and the same puzzles were generated from the same pgn as before, so the result is equivalent.